### PR TITLE
Update GH Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # hear2021-submission-models
 
-Open-source audio embedding models, submitted to the [HEAR 2021
-challenge](https://neuralaudio.ai/hear.html)
+Open-source audio embedding models, submitted to the 2021 NeurIPS HEAR challenge and
+evaluated on the HEAR Benchmark. To find out more about the competition and HEAR benchmark
+please visit https://hearbenchmark.com.
 
 All are pip3-installable, follow the HEAR API, and are open source.
 
-See also the 3 [baseline](https://github.com/neuralaudio/hear-baseline)
+See also the 3 [baseline](https://github.com/hearbenchmark/hear-baseline)
 models.
 
 Information about each model is available in [models.json](models.json),
@@ -15,8 +16,7 @@ us by the authors.
 Model checkpoints, where necessary, are available at
 [Zenodo](https://zenodo.org/record/6332525). Note that some models
 implicitly download their checkpoints from the internet, instead
-of explicitly loading from disk (as per the [HEAR 2021
-rules](https://neuralaudio.ai/hear2021-rules.html)), which reduces
+of explicitly loading from disk (as per the 2021 NeurIPS challenge rule), which reduces
 their replicability.
 
 Models are grouped into three "installation groups". We found that
@@ -25,7 +25,7 @@ co-exist in one installation environment. Group 3 models were
 Tensorflow 2.4 models. Group 2 models were models that could not
 co-exist either with group 1 or group 3 models. Conflicting
 dependencies is the reason we can't provide one pip3-installable
-package for all HEAR 2021 models.
+package for all NeurIPS 2021 HEAR challenge models.
 
 To install a particular model, the steps are:
 
@@ -35,6 +35,6 @@ wget {zenodo_weights_url}
 ```
 
 You can then follow `heareval` as usual. See, for example, [this
-notebook](https://colab.research.google.com/github/neuralaudio/hear-eval-kit/blob/main/heareval_evaluation_example.ipynb).
+notebook](https://colab.research.google.com/github/hearbenchmark/hear-eval-kit/blob/main/heareval_evaluation_example.ipynb).
 
 Model code is mirrored in [`mirror/`](mirror/).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ us by the authors.
 Model checkpoints, where necessary, are available at
 [Zenodo](https://zenodo.org/record/6332525). Note that some models
 implicitly download their checkpoints from the internet, instead
-of explicitly loading from disk (as per the 2021 NeurIPS challenge rule), which reduces
+of explicitly loading from disk (as per the 2021 NeurIPS HEAR challenge rules), which reduces
 their replicability.
 
 Models are grouped into three "installation groups". We found that

--- a/models.json
+++ b/models.json
@@ -155,7 +155,7 @@
     },
     "CREPE": {
         "python_module_name": "hearbaseline.torchcrepe",
-        "git_url": "https://github.com/neuralaudio/hear-baseline",
+        "git_url": "https://github.com/hearbenchmark/hear-baseline",
         "git_rev_2021_12_01": "4478f9fd0d6cbc47fd06c66203b0340d1b5da1ad",
         "code_license": "MIT",
         "data_license": "CC BY 4.0",
@@ -163,7 +163,7 @@
     },
     "wav2vec2": {
         "python_module_name": "hearbaseline.wav2vec2",
-        "git_url": "https://github.com/neuralaudio/hear-baseline",
+        "git_url": "https://github.com/hearbenchmark/hear-baseline",
         "git_rev_2021_12_01": "4478f9fd0d6cbc47fd06c66203b0340d1b5da1ad",
         "code_license": "MIT",
         "data_license": "CC BY 4.0",


### PR DESCRIPTION
Updating README and some links to reflect updated organization name in GitHub. I did not touch any of the links in the mirrored GH repos for the submitted models.